### PR TITLE
Reflect "Queuedjobs by default" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Run the following commands to install the package including both suggestions and
 
 ```
 composer require FriendsOfSilverStripe/silverstripe-maintenance
-composer require silverstripe/queuedjobs
 composer require spekulatius/silverstripe-composer-security-checker
 composer require spekulatius/silverstripe-composer-update-checker
 ```


### PR DESCRIPTION
 Both

 * spekulatius/silverstripe-composer-security-checker

 and

 * spekulatius/silverstripe-composer-update-checker

are requiring queuedjobs by default now - so additional installation isn't required anymore